### PR TITLE
Fix with props checks

### DIFF
--- a/tests/macro/html-component-fail.rs
+++ b/tests/macro/html-component-fail.rs
@@ -62,7 +62,6 @@ fn compile_fail() {
     html! { <Child value=1 with props  ref=()  ref=() /> };
     html! { <Child value=1 ref=() with props ref=() /> };
     html! { <Child ref=() ref=() value=1  with props  /> };
-    html! { <Child ref=() with props /> };
     html! { <Child with blah /> };
     html! { <Child with props () /> };
     html! { <Child value=1 with props /> };

--- a/tests/macro/html-component-fail.stderr
+++ b/tests/macro/html-component-fail.stderr
@@ -66,120 +66,128 @@ error: Using special syntax `with props` along with named prop is not allowed. T
 63 |     html! { <Child value=1 ref=() with props ref=() /> };
    |                                   ^^^^
 
-error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:64:43
+error: too many refs set
+  --> $DIR/html-component-fail.rs:64:27
    |
 64 |     html! { <Child ref=() ref=() value=1  with props  /> };
-   |                                           ^^^^
-
-error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:65:27
-   |
-65 |     html! { <Child ref=() with props /> };
-   |                           ^^^^
+   |                           ^^^
 
 error: unexpected token
-  --> $DIR/html-component-fail.rs:67:31
+  --> $DIR/html-component-fail.rs:66:31
    |
-67 |     html! { <Child with props () /> };
+66 |     html! { <Child with props () /> };
    |                               ^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:68:28
+  --> $DIR/html-component-fail.rs:67:28
    |
-68 |     html! { <Child value=1 with props /> };
+67 |     html! { <Child value=1 with props /> };
    |                            ^^^^
 
 error: Using special syntax `with props` along with named prop is not allowed. This rule does not apply to special `ref` prop
-  --> $DIR/html-component-fail.rs:69:31
+  --> $DIR/html-component-fail.rs:68:31
    |
-69 |     html! { <Child with props value=1 /> };
+68 |     html! { <Child with props value=1 /> };
    |                               ^^^^^
+
+error: expected identifier
+  --> $DIR/html-component-fail.rs:69:20
+   |
+69 |     html! { <Child type=0 /> };
+   |                    ^^^^
 
 error: expected identifier
   --> $DIR/html-component-fail.rs:70:20
    |
-70 |     html! { <Child type=0 /> };
-   |                    ^^^^
-
-error: expected identifier
-  --> $DIR/html-component-fail.rs:71:20
-   |
-71 |     html! { <Child invalid-prop-name=0 /> };
+70 |     html! { <Child invalid-prop-name=0 /> };
    |                    ^^^^^^^^^^^^^^^^^
 
 error: unexpected end of input, expected expression
-  --> $DIR/html-component-fail.rs:73:5
+  --> $DIR/html-component-fail.rs:72:5
    |
-73 |     html! { <Child string= /> };
+72 |     html! { <Child string= /> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error: too many refs set
-  --> $DIR/html-component-fail.rs:78:33
+  --> $DIR/html-component-fail.rs:77:33
    |
-78 |     html! { <Child int=1 ref=() ref=() /> };
+77 |     html! { <Child int=1 ref=() ref=() /> };
    |                                 ^^^
 
 error: this close tag has no corresponding open tag
-  --> $DIR/html-component-fail.rs:81:13
+  --> $DIR/html-component-fail.rs:80:13
    |
-81 |     html! { </Child> };
+80 |     html! { </Child> };
    |             ^^^^^^^^
 
 error: this open tag has no corresponding close tag
-  --> $DIR/html-component-fail.rs:82:13
+  --> $DIR/html-component-fail.rs:81:13
    |
-82 |     html! { <Child><Child></Child> };
+81 |     html! { <Child><Child></Child> };
    |             ^^^^^^^
 
 error: only one root html element allowed
-  --> $DIR/html-component-fail.rs:83:28
+  --> $DIR/html-component-fail.rs:82:28
    |
-83 |     html! { <Child></Child><Child></Child> };
+82 |     html! { <Child></Child><Child></Child> };
    |                            ^^^^^^^^^^^^^^^
+
+error: this close tag has no corresponding open tag
+  --> $DIR/html-component-fail.rs:91:30
+   |
+91 |     html! { <Generic<String>></Generic> };
+   |                              ^^^^^^^^^^
 
 error: this close tag has no corresponding open tag
   --> $DIR/html-component-fail.rs:92:30
    |
-92 |     html! { <Generic<String>></Generic> };
-   |                              ^^^^^^^^^^
-
-error: this close tag has no corresponding open tag
-  --> $DIR/html-component-fail.rs:93:30
-   |
-93 |     html! { <Generic<String>></Generic<Vec<String>>> };
+92 |     html! { <Generic<String>></Generic<Vec<String>>> };
    |                              ^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0425]: cannot find value `blah` in this scope
-  --> $DIR/html-component-fail.rs:66:25
+  --> $DIR/html-component-fail.rs:65:25
    |
-66 |     html! { <Child with blah /> };
+65 |     html! { <Child with blah /> };
    |                         ^^^^ not found in this scope
 
 error[E0609]: no field `unknown` on type `ChildProperties`
-  --> $DIR/html-component-fail.rs:72:20
+  --> $DIR/html-component-fail.rs:71:20
    |
-72 |     html! { <Child unknown="unknown" /> };
+71 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ unknown field
    |
    = note: available fields are: `string`, `int`
 
 error[E0599]: no method named `unknown` found for type `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:72:20
+  --> $DIR/html-component-fail.rs:71:20
    |
 6  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `unknown` not found for this
 ...
-72 |     html! { <Child unknown="unknown" /> };
+71 |     html! { <Child unknown="unknown" /> };
    |                    ^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<(), std::string::String>` is not satisfied
+  --> $DIR/html-component-fail.rs:73:33
+   |
+73 |     html! { <Child int=1 string={} /> };
+   |                                 ^^ the trait `yew::virtual_dom::Transformer<(), std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+   |
+   = help: the following implementations were found:
+             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
+             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
+             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
+             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
+           and 3 others
+   = note: required by `yew::virtual_dom::Transformer::transform`
+
+error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
   --> $DIR/html-component-fail.rs:74:33
    |
-74 |     html! { <Child int=1 string={} /> };
-   |                                 ^^ the trait `yew::virtual_dom::Transformer<(), std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
+74 |     html! { <Child int=1 string=3 /> };
+   |                                 ^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
    |
    = help: the following implementations were found:
              <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
@@ -192,21 +200,7 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
   --> $DIR/html-component-fail.rs:75:33
    |
-75 |     html! { <Child int=1 string=3 /> };
-   |                                 ^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
-   |
-   = help: the following implementations were found:
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, T>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a T, std::option::Option<T>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::option::Option<std::string::String>>>
-             <yew::virtual_dom::vcomp::VComp as yew::virtual_dom::Transformer<&'a str, std::string::String>>
-           and 3 others
-   = note: required by `yew::virtual_dom::Transformer::transform`
-
-error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<{integer}, std::string::String>` is not satisfied
-  --> $DIR/html-component-fail.rs:76:33
-   |
-76 |     html! { <Child int=1 string={3} /> };
+75 |     html! { <Child int=1 string={3} /> };
    |                                 ^^^ the trait `yew::virtual_dom::Transformer<{integer}, std::string::String>` is not implemented for `yew::virtual_dom::vcomp::VComp`
    |
    = help: the following implementations were found:
@@ -218,15 +212,15 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
    = note: required by `yew::virtual_dom::Transformer::transform`
 
 error[E0308]: mismatched types
-  --> $DIR/html-component-fail.rs:77:30
+  --> $DIR/html-component-fail.rs:76:30
    |
-77 |     html! { <Child int=1 ref=() /> };
+76 |     html! { <Child int=1 ref=() /> };
    |                              ^^ expected struct `yew::html::NodeRef`, found `()`
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom::Transformer<u32, i32>` is not satisfied
-  --> $DIR/html-component-fail.rs:79:24
+  --> $DIR/html-component-fail.rs:78:24
    |
-79 |     html! { <Child int=0u32 /> };
+78 |     html! { <Child int=0u32 /> };
    |                        ^^^^ the trait `yew::virtual_dom::Transformer<u32, i32>` is not implemented for `yew::virtual_dom::vcomp::VComp`
    |
    = help: the following implementations were found:
@@ -238,22 +232,33 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VComp: yew::virtual_dom:
    = note: required by `yew::virtual_dom::Transformer::transform`
 
 error[E0599]: no method named `string` found for type `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:80:20
+  --> $DIR/html-component-fail.rs:79:20
    |
 6  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `string` not found for this
 ...
-80 |     html! { <Child string="abc" /> };
+79 |     html! { <Child string="abc" /> };
    |                    ^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
 
 error[E0599]: no method named `children` found for type `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>` in the current scope
-  --> $DIR/html-component-fail.rs:84:5
+  --> $DIR/html-component-fail.rs:83:5
    |
 6  | #[derive(Clone, Properties, PartialEq)]
    |                 ---------- method `children` not found for this
 ...
-84 |     html! { <Child>{ "Not allowed" }</Child> };
+83 |     html! { <Child>{ "Not allowed" }</Child> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildPropertiesBuilder<ChildPropertiesBuilderStep_missing_required_prop_int>`
+   |
+   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
+
+error[E0599]: no method named `build` found for type `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
+  --> $DIR/html-component-fail.rs:85:5
+   |
+23 | #[derive(Clone, Properties)]
+   |                 ---------- method `build` not found for this
+...
+85 |     html! { <ChildContainer /> };
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
@@ -263,26 +268,15 @@ error[E0599]: no method named `build` found for type `ChildContainerPropertiesBu
 23 | #[derive(Clone, Properties)]
    |                 ---------- method `build` not found for this
 ...
-86 |     html! { <ChildContainer /> };
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
-   |
-   = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
-
-error[E0599]: no method named `build` found for type `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>` in the current scope
-  --> $DIR/html-component-fail.rs:87:5
-   |
-23 | #[derive(Clone, Properties)]
-   |                 ---------- method `build` not found for this
-...
-87 |     html! { <ChildContainer></ChildContainer> };
+86 |     html! { <ChildContainer></ChildContainer> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ method not found in `ChildContainerPropertiesBuilder<ChildContainerPropertiesBuilderStep_missing_required_prop_children>`
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<&str>` is not satisfied
-  --> $DIR/html-component-fail.rs:88:5
+  --> $DIR/html-component-fail.rs:87:5
    |
-88 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
+87 |     html! { <ChildContainer>{ "Not allowed" }</ChildContainer> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<&str>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
    |
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `&str`
@@ -290,9 +284,9 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
-  --> $DIR/html-component-fail.rs:89:5
+  --> $DIR/html-component-fail.rs:88:5
    |
-89 |     html! { <ChildContainer><></></ChildContainer> };
+88 |     html! { <ChildContainer><></></ChildContainer> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
    |
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`
@@ -300,9 +294,9 @@ error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::conv
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)
 
 error[E0277]: the trait bound `yew::virtual_dom::vcomp::VChild<Child>: std::convert::From<yew::virtual_dom::vnode::VNode>` is not satisfied
-  --> $DIR/html-component-fail.rs:90:5
+  --> $DIR/html-component-fail.rs:89:5
    |
-90 |     html! { <ChildContainer><other /></ChildContainer> };
+89 |     html! { <ChildContainer><other /></ChildContainer> };
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `std::convert::From<yew::virtual_dom::vnode::VNode>` is not implemented for `yew::virtual_dom::vcomp::VChild<Child>`
    |
    = note: required because of the requirements on the impl of `std::convert::Into<yew::virtual_dom::vcomp::VChild<Child>>` for `yew::virtual_dom::vnode::VNode`

--- a/tests/macro/html-component-pass.rs
+++ b/tests/macro/html-component-pass.rs
@@ -178,12 +178,15 @@ fn compile_pass() {
 
     let props = <Child as Component>::Properties::default();
     let props2 = <Child as Component>::Properties::default();
+    let props3 = <Child as Component>::Properties::default();
+    let props4 = <Child as Component>::Properties::default();
+    let node_ref = NodeRef::default();
     html! {
         <>
             <Child with props />
-
-            // backwards compat
-            <Child: with props2, />
+            <Child: with props2, /> // backwards compat
+            <Child ref=node_ref.clone() with props3 />
+            <Child with props4 ref=node_ref />
         </>
     };
 


### PR DESCRIPTION
Hey @captain-yossarian I started debugging your changes but ran into some design issues with how you refactored parsing. I hope you don't mind, I went ahead and moved some things around and came up with this solution. 

Feel free to do as you please with this PR 😄 

There were a few issues in your implementation:

1. Handling of `with props`

```rust
            let prop_value = stream.parse::<HtmlProp>();	
            if token == "with" {
                is_with = true;
            }	
```

^ When we find `with` we shouldn't parse a full `HtmlProp` because we first need to parse the `props` identity.

2. Handling of errors after calling `return_type`

```rust
        let props_type = match Props::return_type(input) {	
            Ok(props) => Some(props),	
            Err(_) => None,	
        };
```

^ Error doesn't mean that there are no props